### PR TITLE
Resolve hanging when storage is filled up

### DIFF
--- a/src/tryStorage.ts
+++ b/src/tryStorage.ts
@@ -133,7 +133,7 @@ async function performWrites(context: TestContext): Promise<void> {
 
             if (chunkWriteYield.done) {
                 // Ran out of storage.
-                return;
+                return resolve();
             }
 
             const { chunk, duration } = chunkWriteYield.value;


### PR DESCRIPTION
This resolves #3.

The code is properly detecting out-of-space errors, but the handling is not resolving the promise thus causing the flow to hang forever waiting for the promise to be resolved.